### PR TITLE
making it possible to publish raw values, not only json

### DIFF
--- a/app.js
+++ b/app.js
@@ -31,7 +31,7 @@ mqttClient.on('message', (topic, message) =>
   console.log('topic:', topic, message.toString())
 )
 
-app.use(bodyParser.json()) // for parsing application/json
+app.use(bodyParser.text({type:'*/*'}))
 const server = app.listen(port, () => console.log(`Listning on port ${port}!`))
 
 // Check autn in authorization header or token querystring
@@ -54,7 +54,7 @@ const publish = (req, res) => {
 
   mqttClient.publish(
     path,
-    JSON.stringify(req.body),
+    req.body,
     { qos: 0, retain },
     err => {
       console.log('Published', path, req.body)


### PR DESCRIPTION
I don't see the need to parse payload as JSON as it is not used anywhere in the app and it also prevents from publishing raw values as integers.

I'm treating the request body as text to be published on MQTT so this proxy does not impose any restrictions on the payload format.

Now it works for my use case and does not break JSON use case (more elaborate testing might be required to confirm)

Hope you find this useful.