### PR TITLE
fix: restore POST routes under express 5

### DIFF
--- a/app.js
+++ b/app.js
@@ -74,8 +74,10 @@ process.on('SIGTERM', () => {
 })
 
 if (token) {
-  app.post('*', checkAuth, publish)
+  app.post('/', checkAuth, publish)
+  app.post('/*splat', checkAuth, publish)
 } else {
   // dont check auth
-  app.post('*', publish)
+  app.post('/', publish)
+  app.post('/*splat', publish)
 }


### PR DESCRIPTION
## Problem

Since express was bumped to 5.x (path-to-regexp 8.x) the bare wildcard route `app.post('*', ...)` throws:

```
PathError [TypeError]: Missing parameter name at index 1: *
```

The app fails to start on `master` at all, so neither PR #486 nor anything else can be exercised in production.

## Fix

Replace the express 4 wildcard with the express 5 equivalent and explicitly register the root path so `POST /` keeps the behavior the old `app.post('*', ...)` provided:

```diff
-if (token) {
-  app.post('*', checkAuth, publish)
-} else {
-  app.post('*', publish)
-}
+if (token) {
+  app.post('/', checkAuth, publish)
+  app.post('/*splat', checkAuth, publish)
+} else {
+  app.post('/', publish)
+  app.post('/*splat', publish)
+}
```

## Verification

Ran the full test matrix against a real mosquitto broker:

**Routes**
- `POST /` → 204
- `POST /a/b/c` → 204
- `POST /single` → 204
- `GET /` → 404
- `PUT /anything` → 404

**PR #486 raw-payload behavior**
- `POST 12345` (`text/plain`) → published as `12345` ✅
- `POST hello world` → published verbatim ✅
- `POST` no Content-Type → published as-is ✅
- `POST` empty body → published as null ✅

**JSON regression** (wire bytes must match pre-#486)
- `POST {"foo":"bar","n":42}` → published as `{"foo":"bar","n":42}` ✅
- `POST [1,2,3]` → published as `[1,2,3]` ✅
- `POST {"foo":}` (malformed) → 204 (no 400; intentional consequence of #486)
- `POST 42` (JSON scalar) → published as `42` (no 400; intentional consequence of #486)

**Payload size**
- 10 000-byte body → 204, delivered intact ✅

**Auth (`TOKEN=secret123`)**
- no token → 401
- wrong token → 401
- `Authorization` header → 204
- `?token=` querystring → 204
- all of the above on `/` and `/a/b/c` paths

No regressions vs. the pre-#486 / express-4 behavior observed. The route registration covers exactly the same paths the original wildcard did.